### PR TITLE
Update PostCard.jsx

### DIFF
--- a/components/cards/PostCard.jsx
+++ b/components/cards/PostCard.jsx
@@ -1,7 +1,5 @@
 import Image from "next/image";
 import { useState } from "react";
-
-import doc from "public/icons/doc.png";
 import PostViewDialogBox from "../models/PostViewDialogBox";
 
 const PostCard = ({ data }) => {
@@ -19,7 +17,13 @@ const PostCard = ({ data }) => {
       <div className="flex flex-row items-center">
         <div className="">
           <figure className="w-[70px] h-[70px] md:w-20 md:h-20 bg-gray-300 rounded-full overflow-hidden">
-            <Image src={doc} alt={data.description} />
+            {/* Use the absolute path for the image */}
+            <Image 
+              src="/icons/doc.png" 
+              alt={data.description} 
+              width={70} 
+              height={70} 
+            />
           </figure>
         </div>
         <div className="text-start ml-5">


### PR DESCRIPTION
Here’s the updated code with the correct method for handling static assets in Next.js:

Updated PostCard.jsx
Remove Direct Import of Static Asset:

Remove the line where you're importing the image directly.

Use Absolute Path with Image Component:

Update the src attribute of the Image component to use the correct path.